### PR TITLE
Remove trailing whitespace (issue #4)

### DIFF
--- a/test/.golden/T004/golden
+++ b/test/.golden/T004/golden
@@ -3,7 +3,7 @@ an error
   |
 1 | abcdefghijk
   |  ^^  ^^  ^^ z
-  |  |   | 
+  |  |   |
   |  |   | y
   |  | x
 2 | lmnopqrstuv

--- a/test/.golden/T005/golden
+++ b/test/.golden/T005/golden
@@ -3,7 +3,7 @@ an error
   |
 1 |   abcdefghijk
   |  __^^__^^__^^ z
-  | |  |   | 
+  | |  |   |
   | |  |   | y
   | |  | x
 2 | | lmnopqrstuv

--- a/test/.golden/T006/golden
+++ b/test/.golden/T006/golden
@@ -3,7 +3,7 @@ an error
   |
 1 | abcdefghijk
   |  ^^__^^__^^ z
-  |  |   | 
+  |  |   |
   |  |   | y
   |  | x
 2 | lmnopqrstuv

--- a/test/.golden/T007/golden
+++ b/test/.golden/T007/golden
@@ -3,7 +3,7 @@ an error
   |
 1 |   abcdefghijk
   |  __^^__^^  ^^ z
-  | |  | 
+  | |  |
   | |  | x
 2 | | lmnopqrstuv
   | |     ^^^ w

--- a/test/.golden/T009/golden
+++ b/test/.golden/T009/golden
@@ -1,6 +1,6 @@
 an error
 --> here:1:1
   |
-4 | 
+4 |
   | ^ empty
 an error occurred here


### PR DESCRIPTION
Checked and removed all trailing whitespace in files in the  `/test/.golden` directory to address [this issue](https://github.com/1Computer1/errata/issues/4)