### PR TITLE
Fix "Ambiguous occurrence 'golden'"

### DIFF
--- a/test/ErrataSpec.hs
+++ b/test/ErrataSpec.hs
@@ -11,7 +11,7 @@ import           Errata
 import           Errata.Styles
 import           Errata.Types
 import           Test.Hspec
-import           Test.Hspec.Golden
+import           Test.Hspec.Golden (Golden(..))
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
Fix for the following error in ErrataSpec.hs:

Ambiguous occurrence ‘golden’
It could refer to
   either ‘Test.Hspec.Golden.golden’,
          imported from ‘Test.Hspec.Golden’ at .../errata/test/ErrataSpec.hs:14:1-34
       or ‘ErrataSpec.golden’,
          defined at .../errata/test/ErrataSpec.hs:583:1